### PR TITLE
Add a CODE_OF_CONDUCT.md file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+We subscribe to the same [Spotify FOSS Code of Conduct](https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md) that Backstage uses.
+
+## Reporting issues
+
+If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us via foss@roadie.io. All reports will be handled with discretion. In your report please include:
+
+ - Your contact information.
+ - Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.
+- Any additional information that may be helpful.
+
+After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.


### PR DESCRIPTION
This should show up in all public repos which do not have an override.

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file